### PR TITLE
Xml import fixes

### DIFF
--- a/blog/management/commands/wordpress_to_wagtail.py
+++ b/blog/management/commands/wordpress_to_wagtail.py
@@ -292,7 +292,7 @@ class Command(BaseCommand):
                 for record in records:
                     category_name = record['name']
                     new_category = BlogCategory.objects.get_or_create(name=category_name)[0]
-                    if record.get('parent') is not None:
+                    if record.get('parent'):
                         parent_category = BlogCategory.objects.get_or_create(
                             name=record['parent']['name'])[0]
                         parent_category.slug = record['parent']['slug']

--- a/blog/management/commands/wordpress_to_wagtail.py
+++ b/blog/management/commands/wordpress_to_wagtail.py
@@ -102,9 +102,9 @@ class Command(BaseCommand):
             url = 'http:{}'.format(url)
         if url.startswith('/'):
             prefix_url = self.url
-            if prefix_url.endswith('/'):
+            if prefix_url and prefix_url.endswith('/'):
                 prefix_url = prefix_url[:-1]
-            url = '{}{}'.format(prefix_url, url)
+            url = '{}{}'.format(prefix_url or "", url)
         return url
 
     def convert_html_entities(self, text, *args, **options):
@@ -177,7 +177,8 @@ class Command(BaseCommand):
                     self.prepare_url(img['src']))
             except (urllib.error.HTTPError,
                     urllib.error.URLError,
-                    UnicodeEncodeError):
+                    UnicodeEncodeError,
+                    ValueError):
                 print("Unable to import " + img['src'])
                 continue
             image = Image(title=file_, width=width, height=height)


### PR DESCRIPTION
Issues encountered when importing Wordpress XML, thinking they look harmless... unless `record = ""` has a special meaning, which I don't think it does, and that case would break anytime.